### PR TITLE
'skip' is not a container

### DIFF
--- a/ISOBMFF/source/Parser.cpp
+++ b/ISOBMFF/source/Parser.cpp
@@ -267,7 +267,6 @@ void XS::PIMPL::Object< ISOBMFF::Parser >::IMPL::RegisterDefaultBoxes( void )
     this->RegisterContainerBox( "moof" );
     this->RegisterContainerBox( "traf" );
     this->RegisterContainerBox( "mfra" );
-    this->RegisterContainerBox( "skip" );
     this->RegisterContainerBox( "meco" );
     this->RegisterContainerBox( "mere" );
     this->RegisterContainerBox( "dinf" );


### PR DESCRIPTION
* It just contains bytes, not boxes so parsing it is
  very likely to fail