### PR TITLE
Makefile: fix building on Linux with Clang.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,14 +45,13 @@ EXT_CPP             := .cpp
 EXT_M               := .m
 EXT_MM              := .mm
 EXT_H               := .hpp
-CC                  := clang
+CC                  := clang++
 FLAGS_OPTIM         := Os
 FLAGS_WARN          := -Werror -Wall
 FLAGS_STD_C         := c99
 FLAGS_STD_CPP       := c++14
 FLAGS_OTHER         := -fno-strict-aliasing
 FLAGS_C             := 
-FLAGS_CPP           := -x c++ -stdlib=libc++
 FLAGS_M             := -fobjc-arc
 FLAGS_MM            := -fobjc-arc
 XCODE_PROJECT       := ISOBMFF.xcodeproj
@@ -69,8 +68,6 @@ FILES_M_EXCLUDE     :=
 
 FILES_MM            := 
 FILES_MM_EXCLUDE    := 
-
-LIBS                := -lc++
 
 FILES               := $(filter-out $(FILES_C_EXCLUDE),$(FILES_C))      \
                        $(filter-out $(FILES_CPP_EXCLUDE),$(FILES_CPP))  \


### PR DESCRIPTION
Properly set CC variable to clang++ as it's a C++ project and remove unnecessary compiler and linker flags.

This is similar to https://github.com/DigiDNA/ISOBMFF/pull/17.